### PR TITLE
Fixed possible race condition on downloading datasets while using multiple GPUs

### DIFF
--- a/main.py
+++ b/main.py
@@ -44,7 +44,7 @@ def main(args):
 
     if args.distributed:
         if utils.is_main_process():
-            # prepare datasets on main process first to avoid race condition while downloading
+            # prepare datasets on main process first to avoid race condition on downloading datasets
             data_loader, class_mask = build_continual_dataloader(args)
 
         # wait until the main process complete

--- a/main.py
+++ b/main.py
@@ -42,7 +42,19 @@ def main(args):
 
     cudnn.benchmark = True
 
-    data_loader, class_mask = build_continual_dataloader(args)
+    if args.distributed:
+        if utils.is_main_process():
+            # prepare datasets on main process first to avoid race condition while downloading
+            data_loader, class_mask = build_continual_dataloader(args)
+
+        # wait until the main process complete
+        torch.distributed.barrier()
+
+        # let other processes prepare datasets
+        if not utils.is_main_process():
+            data_loader, class_mask = build_continual_dataloader(args)
+    else:
+        data_loader, class_mask = build_continual_dataloader(args)
 
     print(f"Creating original model: {args.model}")
     original_model = create_model(


### PR DESCRIPTION
Hi,
thanks for implementing pytorch version of l2p.

I found an issue.
If we use multiple GPUs to train the model, while downloading datasets, it will have multiple processes to download at the same time and cause file corruption.

So, I updated the `main.py` to let other processes wait until the main process finish loading datasets, then load the rest.